### PR TITLE
Update the method-property match algorithm

### DIFF
--- a/Source/vtkParseProperties.c
+++ b/Source/vtkParseProperties.c
@@ -882,6 +882,23 @@ static int methodMatchesProperty(
     }
   }
 
+  /* signed integer promotion */
+  int methTypeInt = (methType & VTK_PARSE_BASE_TYPE) == VTK_PARSE_INT;
+  int methTypeLong = (methType & VTK_PARSE_BASE_TYPE) == VTK_PARSE_LONG;
+  int methTypeLongLong = (methType & VTK_PARSE_BASE_TYPE) == VTK_PARSE_LONG_LONG;
+  int propertyTypeInt = (propertyType & VTK_PARSE_BASE_TYPE) == VTK_PARSE_INT;
+  int propertyTypeLong = (propertyType & VTK_PARSE_BASE_TYPE) == VTK_PARSE_LONG;
+  int propertyTypeLongLong = (propertyType & VTK_PARSE_BASE_TYPE) == VTK_PARSE_LONG_LONG;
+  if ((methTypeInt && propertyTypeLong) || (methTypeInt && propertyTypeLongLong) ||
+    (methTypeLong && propertyTypeInt) || (methTypeLong && propertyTypeLongLong) ||
+    (methTypeLongLong && propertyTypeInt) || (methTypeLongLong && propertyTypeLong) ||
+    (propertyTypeInt && methTypeLong) || (propertyTypeInt && methTypeLongLong) ||
+    (propertyTypeLong && methTypeInt) || (propertyTypeLong && methTypeLongLong) ||
+    (propertyTypeLongLong && methTypeInt) || (propertyTypeLongLong && methTypeLong))
+  {
+    methType = propertyType;
+  }
+
   /* check for matched type and count */
   if (methType != propertyType || meth->Count != property->Count)
   {

--- a/Source/vtkParseProperties.h
+++ b/Source/vtkParseProperties.h
@@ -22,7 +22,7 @@
 #define VTK_PARSE_PROPERTIES_H
 
 #include "vtkParseData.h"
-#include "vtkParseType.h"
+#include "vtkParseHierarchy.h"
 
 /**
  * bitfield values to say what methods are available for a property
@@ -130,7 +130,8 @@ extern "C" {
 /**
  * Build the ClassProperties struct from a ClassInfo struct
  */
-ClassProperties *vtkParseProperties_Create(ClassInfo *data);
+ClassProperties *vtkParseProperties_Create(ClassInfo *data,
+                                           const HierarchyInfo *hinfo);
 
 /**
  * Free a ClassProperties struct
@@ -148,4 +149,3 @@ const char *vtkParseProperties_MethodTypeAsString(unsigned int methodType);
 #endif
 
 #endif
-


### PR DESCRIPTION
This merge request attempts to fix some observed duplicate occurences of properties.

1. When the method type and property type are able to be promoted among signed integer types, treat them as equal. This is a hack to overcome an inconsitency in vtkContourFilter. Ideally, it should be fixed in VTK - https://gitlab.kitware.com/vtk/vtk/-/merge_requests/10821

2. When the method type derives the property type, consider it as a match.
